### PR TITLE
Use base64 long format "--decode" option

### DIFF
--- a/scripts/jwt-decode.in
+++ b/scripts/jwt-decode.in
@@ -152,7 +152,7 @@ function prepare_base64_cmd()
 {
   command -v base64 > /dev/null 2>&1 &&
     {
-      base64_decode_cmd=( base64 -D )
+      base64_decode_cmd=( base64 --decode )
       return
     }
 


### PR DESCRIPTION
to enhance compatibility with GNU base64
Fixes Issue #1 